### PR TITLE
Add default monitoring subjects

### DIFF
--- a/CommA.py
+++ b/CommA.py
@@ -45,6 +45,8 @@ def run(args):
         with DatabaseDriver.get_session() as s:
             if s.query(Distros).first() is None:
                 s.add_all(Util.Config.default_distros)
+            if s.query(MonitoringSubjects).first() is None:
+                s.add_all(Util.Config.default_monitoring_subjects)
     if args.section:
         Util.Config.sections = args.section
     if args.print_tracked_paths:

--- a/Util/Config.py
+++ b/Util/Config.py
@@ -1,22 +1,45 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-from DatabaseDriver.SqlClasses import Distros
+from DatabaseDriver.SqlClasses import Distros, MonitoringSubjects
 
 dry_run = False
 fetch = True
 since = "4 years ago"
 verbose = 0
-sections = ["Hyper-V CORE AND DRIVERS", "COMMON INTERNET FILE SYSTEM"]
+sections = ["Hyper-V CORE AND DRIVERS"]
 default_distros = [
+    Distros(
+        distroID="Ubuntu16.04",
+        repoLink="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/xenial",
+    ),
+    Distros(
+        distroID="Ubuntu18.04",
+        repoLink="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/bionic",
+    ),
+    Distros(
+        distroID="Ubuntu19.04",
+        repoLink="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/disco",
+    ),
     Distros(
         distroID="Ubuntu19.10",
         repoLink="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/eoan",
+    ),
+    Distros(
+        distroID="Ubuntu20.04",
+        repoLink="https://git.launchpad.net/~canonical-kernel/ubuntu/+source/linux-azure/+git/focal",
     ),
     Distros(
         distroID="Debian9-backport",
         repoLink="https://salsa.debian.org/kernel-team/linux.git",
     ),
     Distros(distroID="SUSE12", repoLink="https://github.com/openSUSE/kernel",),
+]
+
+# NOTE: The Ubuntu kernels get revisions added automatically by
+# checking the remote repos’ tags.
+default_monitoring_subjects = [
+    MonitoringSubjects(distroID="Debian9-backport", revision="stretch-backports"),
+    MonitoringSubjects(distroID="SUSE12", revision="SUSE12/SLE12-SP5-AZURE"),
 ]
 
 """


### PR DESCRIPTION
So that the dry run is accurate (we need the revisions for the default distros). Also remove CIFS so the dry run is faster.