### PR TITLE
Fix --bare and --contains bugs

### DIFF
--- a/DatabaseDriver/Credentials.py
+++ b/DatabaseDriver/Credentials.py
@@ -27,7 +27,7 @@ class DatabaseCredentials:
         # _server_ from which we're cloning does not support
         # `--shallow-since`, so we have to disable this here.
         Util.Tracking.get_repo(
-            name="secrets", url=secrets_url, bare=False, shallow=False, pull=True
+            name="secrets", url=secrets_url, shallow=False, pull=True
         )
 
         root = xml.etree.ElementTree.parse(

--- a/DownstreamTracker/MonitorDownstream.py
+++ b/DownstreamTracker/MonitorDownstream.py
@@ -89,7 +89,7 @@ def monitor_subject(monitoring_subject, repo):
         "--right-only",
         "--cherry-pick",
         "--pretty=format:%H",
-        f"{monitoring_subject.revision}...master",
+        f"{monitoring_subject.revision}...origin/master",
         "--",
         get_tracked_paths(),
     ).split("\n")

--- a/UpstreamTracker/ParseData.py
+++ b/UpstreamTracker/ParseData.py
@@ -30,7 +30,7 @@ def should_keep_line(line: str):
 
 def process_commits(
     commit_ids: Optional[Set[str]] = None,
-    revision: str = "master",
+    revision: str = "origin/master",
     add_to_database: bool = False,
     since: str = Util.Config.since,
 ) -> List[PatchData]:

--- a/Util/Symbols.py
+++ b/Util/Symbols.py
@@ -50,7 +50,7 @@ def map_symbols_to_patch(
     commits: SHA of all commits in database
     fileNames: hyperV files
     """
-    repo = get_repo(name="linux-sym", bare=False, shallow=False, pull=True)
+    repo = get_repo(name="linux-sym", shallow=False, pull=True)
     repo.head.reference = repo.commit(prev_commit)
     repo.head.reset(index=True, working_tree=True)
     before_patch_apply = None

--- a/Util/Tracking.py
+++ b/Util/Tracking.py
@@ -31,15 +31,15 @@ UPDATED_REPOS = set()
 def get_repo(
     name: str,
     url: str = "https://github.com/torvalds/linux.git",
-    bare: bool = True,
     shallow: bool = True,
     pull: bool = False,
 ) -> git.Repo:
     """Clone and optionally update a repo, returning the object.
 
-    By default this clones the Linux repo to 'name' from 'url',
-    optionally 'bare', and returns the 'git.Repo' object. It only
-    fetches or pulls once per session, and only if told to do so.
+    By default this clones the Linux repo to 'name' from 'url', and
+    returns the 'git.Repo' object. It only fetches or pulls once per
+    session, and only if told to do so.
+
     """
     global UPDATED_REPOS
     repo = None
@@ -62,7 +62,7 @@ def get_repo(
                 logging.info("Fetched!")
     else:
         logging.info(f"Cloning '{name}' repo from '{url}'...")
-        args = {"bare": bare}
+        args = {}
         if shallow:
             args.update({"shallow_since": Util.Config.since})
         repo = git.Repo.clone_from(url, path, **args)
@@ -124,7 +124,7 @@ def get_tracked_paths(sections=Util.Config.sections) -> List[str]:
     # All tag commits starting with v4, also master.
     tags = repo.git.tag("v[^123]*", list=True).split()
     commits = [c for c in tags if re.match(r"v[0-9]+\.[0-9]+$", c)]
-    commits.append("master")
+    commits.append("origin/master")
     for commit in commits:
         maintainers = repo.git.show(f"{commit}:MAINTAINERS").split("\n")
         for section in sections:


### PR DESCRIPTION
# Undo `--bare` cloning of linux.git

This just...causes problems. While we _don’t_ want a worktree, and
having one _may_ cause problems, a bare clone doesn’t maintain an
`origin/*` set of refs. Instead, it maps them into the local refs (that
is, what is normally `origin/master` is just `master`). In and of
itself, this is fine, but `git fetch --all` has problems with this, and
we do not want to fetch twice just to be able to update the local master
branch with the remote master branch. That is, `git fetch origin
master:master` does solve this problem, but requires a second fetch on
top of the `git fetch --all` we do because we have multiple remotes.
Finally, that local `master` branch, not being a remote namespace,
starts to get confused with the other remotes’ `master` branches. So we
are saying good-bye to the bare clone.

# Handle `git describe --contains` failing

Which can happen depending on the status of the Git repo.
