### PR TITLE
fetch_remote_ref() improvements

### DIFF
--- a/comma/__init__.py
+++ b/comma/__init__.py
@@ -4,4 +4,4 @@
 CommA Commit Analyzer
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
Previously, the fetch at depth 1, which acts as a guard for repos that don't support `shallow_since`, wiped out the existing depth causing unnecessary replication. Now, the existing local ref if validated and used if it exists.