### PR TITLE
[0.4.2] Spreadsheet commit update fixes and improvements

### DIFF
--- a/comma/__init__.py
+++ b/comma/__init__.py
@@ -4,4 +4,4 @@
 CommA Commit Analyzer
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/comma/cli/__init__.py
+++ b/comma/cli/__init__.py
@@ -156,7 +156,7 @@ def main(args: Optional[Sequence[str]] = None):
     logging.basicConfig(
         level={0: logging.WARNING, 1: logging.INFO}.get(options.verbose, logging.DEBUG),
         format="%(asctime)s %(name)-5s %(levelname)-7s %(message)s",
-        datefmt="%m-%d %H:%M",
+        datefmt="%m-%d %H:%M:%S",
     )
 
     # Start with a basic configuration object

--- a/comma/util/spreadsheet.py
+++ b/comma/util/spreadsheet.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, Tuple
 
 import git
 import openpyxl
-import sqlalchemy
 from openpyxl.cell.cell import Cell
 from openpyxl.workbook.workbook import Workbook
 from openpyxl.worksheet.worksheet import Worksheet
@@ -187,12 +186,11 @@ class Spreadsheet:
         # NOTE: For some distros (e.g. Ubuntu), we continually add new revisions (Git tags) as they
         # become available, so we need the max ID, which is the most recent.
         with self.database.get_session() as session:
-            subject, _ = (
-                session.query(
-                    MonitoringSubjects,
-                    sqlalchemy.func.max(MonitoringSubjects.monitoringSubjectID),
-                )
+            subject = (
+                session.query(MonitoringSubjects)
                 .filter_by(distroID=distro)
+                .order_by(MonitoringSubjects.monitoringSubjectID.desc())
+                .limit(1)
                 .one()
             )
 


### PR DESCRIPTION
- Adds seconds to log messages
- Adds additional log messages for spreadsheet commit updating
- Refactor spreadsheet commit updating
  - >50% reduction in completion time
- Fix bug where highest monitoring subject ID was determined before filtering for remote
