### PR TITLE
0.5.0

### DIFF
--- a/comma.yaml
+++ b/comma.yaml
@@ -26,3 +26,8 @@ downstream:
     reference: stretch-backports
   - repo: Debian10-backport
     reference: bullseye-backports
+
+spreadsheet:
+  excluded_paths:
+    - '%fs/cifs%'
+    - '%tools/hv/%'

--- a/comma.yaml
+++ b/comma.yaml
@@ -28,6 +28,7 @@ downstream:
     reference: bullseye-backports
 
 spreadsheet:
+  # Commits that include excluded paths are not included in spreadsheet exports
   excluded_paths:
-    - '%fs/cifs%'
-    - '%tools/hv/%'
+    # - '%fs/cifs%'
+    # - '%tools/hv/%'

--- a/comma/__init__.py
+++ b/comma/__init__.py
@@ -4,4 +4,4 @@
 CommA Commit Analyzer
 """
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"

--- a/comma/cli/__init__.py
+++ b/comma/cli/__init__.py
@@ -125,6 +125,12 @@ class Session:
         if options.action == "add":
             self.database.add_downstream_target(options.name, options.url, options.revision)
 
+        elif options.action == "delete":
+            if options.revision:
+                self.database.delete_downstream_target(options.name, options.revision)
+            else:
+                self.database.delete_repo(options.name)
+
     def spreadsheet(self, options):
         """
         Handle spreadsheet subcommand

--- a/comma/cli/__init__.py
+++ b/comma/cli/__init__.py
@@ -13,7 +13,7 @@ from ruamel.yaml import YAML as R_YAML
 from ruamel.yaml import YAMLError
 
 from comma.cli.parser import parse_args
-from comma.config import BaseConfig, Config
+from comma.config import BasicConfig, FullConfig
 from comma.database.driver import DatabaseDriver
 from comma.database.model import Distros, MonitoringSubjects
 from comma.downstream import Downstream
@@ -33,7 +33,7 @@ class Session:
     """
 
     def __init__(self, config, database) -> None:
-        self.config: Config = config
+        self.config: FullConfig = config
         self.database: DatabaseDriver = database
 
     def _get_repo(
@@ -161,16 +161,16 @@ def main(args: Optional[Sequence[str]] = None):
 
     # If a full configuration is required, CLI parser would ensure this is set
     if options.config:
-        options_values = {field: getattr(options, field, None) for field in BaseConfig.__fields__}
+        options_values = {field: getattr(options, field, None) for field in BasicConfig.__fields__}
         try:
-            config = Config(**YAML.load(options.config) | options_values)
+            config = FullConfig(**YAML.load(options.config) | options_values)
         except (ValidationError, YAMLError) as e:
             print(f"Unable to validate config file: {options.config}")
             sys.exit(e)
 
     # Fallback to basic configuration
     else:
-        config: BaseConfig = BaseConfig(**vars(options))
+        config: BasicConfig = BasicConfig(**vars(options))
 
     # Get database object
     database = DatabaseDriver(dry_run=options.dry_run, echo=options.verbose > 2)

--- a/comma/cli/__init__.py
+++ b/comma/cli/__init__.py
@@ -92,7 +92,7 @@ class Session:
 
         if options.upstream:
             LOGGER.info("Begin monitoring upstream")
-            Upstream(self.config, self.database, repo).process_commits()
+            Upstream(self.config, self.database, repo).process_commits(options.force_update)
             LOGGER.info("Finishing monitoring upstream")
 
         if options.downstream:

--- a/comma/cli/__init__.py
+++ b/comma/cli/__init__.py
@@ -17,6 +17,7 @@ from comma.config import BasicConfig, FullConfig
 from comma.database.driver import DatabaseDriver
 from comma.database.model import Distros, MonitoringSubjects
 from comma.downstream import Downstream
+from comma.exceptions import CommaError
 from comma.upstream import Upstream
 from comma.util.spreadsheet import Spreadsheet
 from comma.util.symbols import Symbols
@@ -172,11 +173,15 @@ def main(args: Optional[Sequence[str]] = None):
     else:
         config: BasicConfig = BasicConfig(**vars(options))
 
-    # Get database object
-    database = DatabaseDriver(dry_run=options.dry_run, echo=options.verbose > 2)
+    try:
+        # Get database object
+        database = DatabaseDriver(dry_run=options.dry_run, echo=options.verbose > 2)
 
-    # Create session object and invoke subcommand
-    Session(config, database)(options)
+        # Create session object and invoke subcommand
+        Session(config, database)(options)
+
+    except CommaError as e:
+        sys.exit(f"ERROR: {e}")
 
 
 if __name__ == "__main__":

--- a/comma/cli/parser.py
+++ b/comma/cli/parser.py
@@ -177,6 +177,15 @@ def get_downstream_parser():
     )
 
     actions.add_argument(
+        "-D",
+        "--delete",
+        action="store_const",
+        const="delete",
+        dest="action",
+        help="Delete downstream target, must specify name, revision optional",
+    )
+
+    actions.add_argument(
         "-l",
         "--list",
         action="store_const",
@@ -193,7 +202,7 @@ def get_downstream_parser():
     parser.add_argument(
         "-u",
         "--url",
-        help="Repository URL. Required if repo in not in database",
+        help="Repository URL. Required for add if repo in not in database",
     )
     parser.add_argument(
         "-r",
@@ -229,12 +238,12 @@ def parse_args(args: Optional[Sequence[str]] = None):
 
     # Check for required options
     options = parser.parse_args(args)
-    if (
-        options.subcommand == "downstream"
-        and options.action == "add"
-        and None in (options.name, options.revision)
-    ):
-        parser.error("URL and revision are required")
+
+    if options.subcommand == "downstream":
+        if options.action == "add" and None in (options.name, options.revision):
+            parser.error("Name and revision are required")
+        elif options.action == "delete" and options.name is None:
+            parser.error("Name is required")
 
     # Configuration file was specified
     if options.config is not None:

--- a/comma/cli/parser.py
+++ b/comma/cli/parser.py
@@ -89,6 +89,11 @@ def get_run_parser():
         metavar="APPROXIDATE",
         help="Passed to underlying git commands. By default, the history is not limited",
     )
+    parser.add_argument(
+        "--force-update",
+        action="store_true",
+        help="Force update to existing upstream patch records",
+    )
 
     return parser
 

--- a/comma/config.py
+++ b/comma/config.py
@@ -31,7 +31,7 @@ class Upstream(BaseModel):
     sections: Tuple[str, ...]
 
 
-class BaseConfig(BaseModel):
+class BasicConfig(BaseModel):
     """
     Minimal configuration model
     """
@@ -51,9 +51,11 @@ class BaseConfig(BaseModel):
         validate_assignment = True
 
 
-class Config(BaseConfig):
+class FullConfig(BasicConfig):
     """
-    Main configuration model
+    Full configuration model
+    Requires:
+        upstream to be defined
     """
 
     repos: Dict[str, AnyUrl]

--- a/comma/config.py
+++ b/comma/config.py
@@ -31,6 +31,14 @@ class Upstream(BaseModel):
     sections: Tuple[str, ...]
 
 
+class Spreadsheet(BaseModel):
+    """
+    Model for spreadsheet configuration
+    """
+
+    excluded_paths: Optional[Tuple[str, ...]]
+
+
 class BasicConfig(BaseModel):
     """
     Minimal configuration model
@@ -61,6 +69,7 @@ class FullConfig(BasicConfig):
     repos: Dict[str, AnyUrl]
     upstream: Upstream
     downstream: Optional[Tuple[Target, ...]]
+    spreadsheet: Optional[Spreadsheet] = Spreadsheet()
 
     @validator("repos")
     def check_repo(cls, repos):

--- a/comma/config.py
+++ b/comma/config.py
@@ -6,8 +6,9 @@ Configuration data model
 
 from typing import Dict, Optional, Tuple
 
-import approxidate
 from pydantic import AnyUrl, BaseModel, validator
+
+from comma.util import DateString
 
 
 class Target(BaseModel):
@@ -35,16 +36,19 @@ class BaseConfig(BaseModel):
     Minimal configuration model
     """
 
-    downstream_since: Optional[str] = None
-    upstream_since: Optional[str] = None
+    downstream_since: Optional[DateString] = None
+    upstream_since: Optional[DateString] = None
 
     @validator("downstream_since", "upstream_since")
-    def check_date(cls, value: str):
-        """Ensure date can be interpreted"""
+    def coerce_date(cls, value: str):
+        """Coerce date string"""
 
-        approxidate.approx(value)
+        return value if value is None else DateString(value)
 
-        return value
+    class Config:
+        """Model configuration"""
+
+        validate_assignment = True
 
 
 class Config(BaseConfig):

--- a/comma/config.py
+++ b/comma/config.py
@@ -68,7 +68,7 @@ class FullConfig(BasicConfig):
 
     repos: Dict[str, AnyUrl]
     upstream: Upstream
-    downstream: Optional[Tuple[Target, ...]]
+    downstream: Optional[Tuple[Target, ...]] = ()
     spreadsheet: Optional[Spreadsheet] = Spreadsheet()
 
     @validator("repos")

--- a/comma/database/driver.py
+++ b/comma/database/driver.py
@@ -7,13 +7,13 @@ Provide a class for managing database connections and sessions
 
 import logging
 import os
-import sys
 import urllib
 from contextlib import contextmanager
 
 import sqlalchemy
 
 from comma.database.model import Base, Distros, MonitoringSubjects
+from comma.exceptions import CommaDatabaseError, CommaDataError
 
 
 LOGGER = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ class DatabaseDriver:
         # Verify credentials are available
         for envvar in ("COMMA_DB_URL", "COMMA_DB_NAME", "COMMA_DB_USERNAME", "COMMA_DB_PW"):
             if not os.environ.get(envvar):
-                sys.exit(f"{envvar} is not defined in the current environment")
+                raise CommaDatabaseError(f"{envvar} is not defined in the current environment")
 
         params = urllib.parse.quote_plus(
             ";".join(
@@ -137,7 +137,7 @@ class DatabaseDriver:
 
             # If URL wasn't given, make sure repo is in database
             elif (name,) not in session.query(Distros.distroID).all():
-                sys.exit(f"Repository '{name}' given without URL not found in database")
+                raise CommaDataError(f"Repository '{name}' given without URL not found in database")
 
             # Add target
             session.add(MonitoringSubjects(distroID=name, revision=revision))

--- a/comma/downstream/__init__.py
+++ b/comma/downstream/__init__.py
@@ -58,6 +58,9 @@ class Downstream:
             subjects = session.query(MonitoringSubjects).all()
             total = len(subjects)
 
+            if not total:
+                LOGGER.warning("No downstream targets defined")
+
             for num, subject in enumerate(subjects, 1):
                 if subject.distroID.startswith("Debian"):
                     # TODO (Issue 51): Don't skip Debian

--- a/comma/exceptions.py
+++ b/comma/exceptions.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""
+Custom exception types
+"""
+
+
+class CommaError(Exception):
+    """Comma parent exception class"""
+
+
+class CommaDatabaseError(CommaError):
+    """Errors establishing database connections"""
+
+
+class CommaDataError(CommaError):
+    """Errors with input or stored data"""
+
+
+class CommaSpreadsheetError(CommaError):
+    """Errors with spreadsheet operations"""

--- a/comma/upstream.py
+++ b/comma/upstream.py
@@ -22,13 +22,14 @@ class Upstream:
         self.database = database
         self.repo = repo
 
-    def process_commits(self):
+    def process_commits(self, force_update=False):
         """
         Generate patches for commits affecting tracked paths
         """
 
         paths = self.repo.get_tracked_paths(self.config.upstream.sections)
         added = 0
+        updated = 0
         total = 0
 
         # We use `--min-parents=1 --max-parents=1` to avoid both merges and graft commits.
@@ -42,14 +43,42 @@ class Upstream:
         ):
             total += 1
             with self.database.get_session() as session:
-                # See if commit ID is in database
-                if (
-                    session.query(PatchData.commitID)
-                    .filter_by(commitID=commit.hexsha)
-                    .one_or_none()
-                    is None
-                ):
+                # Query database for commit
+                if force_update:
+                    query = session.query(PatchData)
+                else:
+                    query = session.query(PatchData.commitID)
+                patch = query.filter_by(commitID=commit.hexsha).one_or_none()
+
+                # If commit is missing, add it
+                if patch is None:
                     session.add(PatchData.create(commit, paths))
                     added += 1
 
+                # If commit is present, optionally update
+                elif force_update:
+                    # Get a local patch object
+                    patch_data = PatchData.create(commit, paths)
+
+                    # Iterate through the columns
+                    record_updated = False
+                    for column in (
+                        col.name for col in patch_data.__table__.columns if not col.primary_key
+                    ):
+                        # Skip commit ID
+                        if column == "commitID":
+                            continue
+
+                        # If the new value is different, update it
+                        new_value = getattr(patch_data, column)
+                        if getattr(patch, column) != new_value:
+                            LOGGER.info("Updating %s for %s", column, commit.hexsha)
+                            setattr(patch, column, new_value)
+                            record_updated = True
+
+                    if record_updated:
+                        updated += 1
+
         LOGGER.info("%d of %d patches added to database.", added, total)
+        if force_update:
+            LOGGER.info("%d of %d patches updated in database.", updated, total)

--- a/comma/util/__init__.py
+++ b/comma/util/__init__.py
@@ -4,6 +4,18 @@
 Utility functions and classes
 """
 
+import approxidate
+
+
+class DateString(str):
+    """
+    Wrapper for build-in string type with an additional attribute, epoch
+    """
+
+    def __init__(self, object_, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.epoch: float = approxidate.approx(str(object_))
+
 
 def format_diffs(commit, paths):
     """

--- a/comma/util/__init__.py
+++ b/comma/util/__init__.py
@@ -4,6 +4,8 @@
 Utility functions and classes
 """
 
+from datetime import datetime
+
 import approxidate
 
 
@@ -15,6 +17,7 @@ class DateString(str):
     def __init__(self, object_, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.epoch: float = approxidate.approx(str(object_))
+        self.datetime = datetime.utcfromtimestamp(self.epoch)
 
 
 def format_diffs(commit, paths):

--- a/comma/util/spreadsheet.py
+++ b/comma/util/spreadsheet.py
@@ -281,7 +281,7 @@ class Spreadsheet:
                     # what’s missing, it becomes hard to state where the patch is present.
                     missing_patch = subject.missingPatches.filter_by(patchID=patch_id).one_or_none()
                     worksheet.get_cell(distro, commit_cell.row).value = (
-                        subject.revision if missing_patch is None else "Absent"
+                        "Absent" if missing_patch is None else subject.revision
                     )
 
             LOGGER.info("Updates evaluated for %s rows", total_rows)

--- a/comma/util/spreadsheet.py
+++ b/comma/util/spreadsheet.py
@@ -177,7 +177,7 @@ class Spreadsheet:
         # Get commits in database, but not in spreadsheet
         # Exclude ~1000 CIFS patches and anything that touches tools/hv  # pylint: disable=wrong-spelling-in-comment
         missing_commits = self.get_db_commits(
-            since=self.config.upstream_since.epoch,
+            since=self.config.upstream_since.datetime,
             excluded_paths=self.config.spreadsheet.excluded_paths,
         ).keys() - {cell.value for cell in worksheet.get_column_cells("Commit ID")}
 

--- a/comma/util/tracking.py
+++ b/comma/util/tracking.py
@@ -26,7 +26,7 @@ def get_filenames(commit: git.Commit) -> List[str]:
         return []
     diffs = commit.tree.diff(commit.parents[0])
     # Sometimes a path is in A and not B but we want all filenames.
-    return list(
+    return sorted(
         {diff.a_path for diff in diffs if diff.a_path is not None}
         | {diff.b_path for diff in diffs if diff.b_path is not None}
     )

--- a/comma/util/tracking.py
+++ b/comma/util/tracking.py
@@ -22,7 +22,7 @@ def get_filenames(commit: git.Commit) -> List[str]:
     Get all paths affected by a given commit
     """
 
-    if commit.parents:
+    if not commit.parents:
         return []
     diffs = commit.tree.diff(commit.parents[0])
     # Sometimes a path is in A and not B but we want all filenames.

--- a/comma/util/tracking.py
+++ b/comma/util/tracking.py
@@ -9,8 +9,9 @@ import pathlib
 import re
 from typing import Any, Iterable, List, Optional, Set, Tuple
 
-import approxidate
 import git
+
+from comma.util import DateString
 
 
 LOGGER = logging.getLogger(__name__)
@@ -128,7 +129,7 @@ class Repo:
         return self._tracked_paths
 
     def fetch_remote_ref(
-        self, remote: str, local_ref: str, remote_ref: str, since: Optional[str] = None
+        self, remote: str, local_ref: str, remote_ref: str, since: Optional[DateString] = None
     ) -> None:
         """
         Shallow fetch remote reference so it is available locally
@@ -178,7 +179,7 @@ class Repo:
         # If last commit for revision is in the fetch window, expand depth
         # This check is necessary because some servers will throw an error when there are
         # no commits in the fetch window
-        if commit_date >= approxidate.approx(since):
+        if commit_date >= since.epoch:
             LOGGER.info(
                 'Fetching ref %s from remote %s shallow since "%s"',
                 remote_ref,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ spelling-ignore-words = [
   "iterable", "isort",
   "monitoringSubject",
   "namespace", "Nox",
-  "ORM",
+  "ORM", "openpyxl",
   "parsers", "PatchData", "preprocessing",
   "repo", "repos",
   "setuptools", "SHA", "subclassed", "subcommand", "subcommands", "subparsers",


### PR DESCRIPTION
Changes:
- Improve how `--upstream-since` and `--downstream-since` are applied and stored in config
- Bugfix: Affected files was not being populated correctly
- Bugfix: revision not selected correctly on update
- Use `--upstream-since` for spreadsheet rather than a hard-coded tag
- Consolidate spreadsheet path exceptions and add config option
- Remove existing spreadsheet path exceptions
- Add warning when no downstream targets are defined
- Sort spreadsheet on export
- Add `--force-update` option to update existing database records for upstream commits
- Add capability to delete repos and targets from database
- Code cleanup and optimizations

Closes
- #50 
- #68 
- #72 
- #42 

Partially completes
- #28 